### PR TITLE
비효율적인 코드 개선

### DIFF
--- a/main.py
+++ b/main.py
@@ -96,22 +96,18 @@ while True:
 
     split = title.split(" - ")
 
-    song = split[0]
     try:
-        # Seven (feat. Latto) - Clean ver - 정국 같은 경우, Clean ver이 아티스트가 되기에 이렇게 처리.
-        for i in range(0,100):
-            artist = split[i]
-    except:
-        pass
-    if song is None and artist is None:
-        error("Failed to get song info. Are you closed Melon Player?")
-        continue
-    info(f"Playing {song} - {artist}")
+        song = " - ".join(split[:-1])
+        artist = split[-1]
 
-    rpc.set_activity(
-        state=f"{artist}",
-        details=song,
-        large_image="melon",
-        large_text="멜론 PC 플레이어",
-        timestamp=time.mktime(time.localtime())
-    )
+        info(f"Playing {song} - {artist}")
+
+        rpc.set_activity(
+            state=f"{artist}",
+            details=song,
+            large_image="melon",
+            large_text="멜론 PC 플레이어",
+            timestamp=time.mktime(time.localtime())
+        )
+    except:
+        error("Failed to get song info. Are you closed Melon Player?")


### PR DESCRIPTION
https://github.com/norhu1130/MelonRPC/blob/1686554e4ae1a651526333a54f7be3777f3b6ffc/main.py#L102

위 코드와 같이 반복문을 돌리는 대신, 다음과 같이 간단히 표현할 수 있습니다.
```py
artist = split[-1]
```
또한,  `Seven (feat. Latto) - Clean ver - 정국` 같은 텍스트의 제목에서 - Clean ver가 사라지는 문제점 역시 아래 코드로 해결하였습니다.
```py
song = " - ".join(split[:-1])
```